### PR TITLE
docs: fix typo in open-url API docs

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -128,8 +128,8 @@ Emitted when the user wants to open a URL with the application. Your application
 set `NSPrincipalClass` to `AtomApplication`.
 
 As with the `open-file` event, be sure to register a listener for the `open-url`
-event early in your application startup to detect if the application is being opened to handle a URL. If you register the listener in response to a
-`ready` event, you'll miss URLs that trigger the launch of your application.
+event early in your application startup to detect if the application is being opened to handle a URL.
+If you register the listener in response to a `ready` event, you'll miss URLs that trigger the launch of your application.
 
 ### Event: 'activate' _macOS_
 

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -128,8 +128,7 @@ Emitted when the user wants to open a URL with the application. Your application
 set `NSPrincipalClass` to `AtomApplication`.
 
 As with the `open-file` event, be sure to register a listener for the `open-url`
-event early in your application startup to detect if the the application being
-is being opened to handle a URL. If you register the listener in response to a
+event early in your application startup to detect if the application is being opened to handle a URL. If you register the listener in response to a
 `ready` event, you'll miss URLs that trigger the launch of your application.
 
 ### Event: 'activate' _macOS_


### PR DESCRIPTION
#### Description of Change

Pretty self explanatory. Found a typo in the docs here

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] tests are [changed or added](https://github.com/electron/electron/blob/main/docs/development/testing.md)
- [X] relevant documentation, tutorials, templates and examples are changed or added
- [X] [PR release notes](https://github.com/electron/clerk/blob/main/README.md) describe the change in a way relevant to app developers, and are [capitalized, punctuated, and past tense](https://github.com/electron/clerk/blob/main/README.md#examples).

#### Release Notes

none
